### PR TITLE
Remove permissions that are no longer available

### DIFF
--- a/linkedin/linkedin.py
+++ b/linkedin/linkedin.py
@@ -25,15 +25,11 @@ allowed.  I will put the ones here in the comments that I have removed:
 """
 
 PERMISSIONS = enum('Permission',
-                   COMPANY_ADMIN='rw_company_admin',
                    BASIC_PROFILE='r_basicprofile',
-                   FULL_PROFILE='r_fullprofile',
                    EMAIL_ADDRESS='r_emailaddress',
-                   NETWORK='r_network',
-                   CONTACT_INFO='r_contactinfo',
-                   NETWORK_UPDATES='rw_nus',
-                   GROUPS='rw_groups',
-                   MESSAGES='w_messages')
+                   COMPANY_ADMIN='rw_company_admin',
+                   SHARE='w_share'
+                   )
 
 ENDPOINTS = enum('LinkedInURL',
                  PEOPLE='https://api.linkedin.com/v1/people',


### PR DESCRIPTION
LinkedIn have removed a number of permissions from the API, r_basicprofile, r_emailaddress, rw_company_admin and w_share are the only available types.
